### PR TITLE
Холин Кирилл. Задача 1. Вариант 9. Технология STL. Вычисление многомерных интегралов с использованием многошаговой схемы (метод прямоугольников)

### DIFF
--- a/tasks/stl/kholin_k_multidimensional_integrals_rectangle/func_tests/main.cpp
+++ b/tasks/stl/kholin_k_multidimensional_integrals_rectangle/func_tests/main.cpp
@@ -1,0 +1,409 @@
+#include <gtest/gtest.h>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+#include "core/util/include/util.hpp"
+#include "stl/kholin_k_multidimensional_integrals_rectangle/include/ops_stl.hpp"
+
+TEST(kholin_k_multidimensional_integrals_rectangle_stl, test_validation) {
+  // Create data
+  size_t dim = 1;
+  std::vector<double> values{0.0};
+  auto f = [](const std::vector<double> &f_values) { return std::sin(f_values[0]); };
+  std::vector<double> in_lower_limits{0};
+  std::vector<double> in_upper_limits{1};
+  double n = 10.0;
+  std::vector<double> out_i(1, 0.0);
+
+  auto f_object = std::make_unique<std::function<double(const std::vector<double> &)>>(f);
+
+  // Create task_data
+  std::shared_ptr<ppc::core::TaskData> task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(f_object.get()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+  task_data_stl->inputs_count.emplace_back(values.size());
+  task_data_stl->inputs_count.emplace_back(in_lower_limits.size());
+  task_data_stl->inputs_count.emplace_back(in_upper_limits.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+  task_data_stl->outputs_count.emplace_back(out_i.size());
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_stl, test_pre_processing) {
+  // Create data
+  size_t dim = 1;
+  std::vector<double> values{0.0};
+  auto f = [](const std::vector<double> &f_values) { return std::sin(f_values[0]); };
+  std::vector<double> in_lower_limits{0};
+  std::vector<double> in_upper_limits{1};
+  double n = 10.0;
+  std::vector<double> out_i(1, 0.0);
+
+  auto f_object = std::make_unique<std::function<double(const std::vector<double> &)>>(f);
+
+  // Create task_data
+  std::shared_ptr<ppc::core::TaskData> task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(f_object.get()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+  task_data_stl->inputs_count.emplace_back(values.size());
+  task_data_stl->inputs_count.emplace_back(in_lower_limits.size());
+  task_data_stl->inputs_count.emplace_back(in_upper_limits.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+  task_data_stl->outputs_count.emplace_back(out_i.size());
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  ASSERT_EQ(test_task_stl.PreProcessing(), true);
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_stl, test_run) {
+  // Create data
+  size_t dim = 1;
+  std::vector<double> values{0.0};
+  auto f = [](const std::vector<double> &f_values) { return std::sin(f_values[0]); };
+  std::vector<double> in_lower_limits{0};
+  std::vector<double> in_upper_limits{1};
+  double n = 10.0;
+  std::vector<double> out_i(1, 0.0);
+
+  auto f_object = std::make_unique<std::function<double(const std::vector<double> &)>>(f);
+
+  // Create task_data
+  std::shared_ptr<ppc::core::TaskData> task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(f_object.get()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+  task_data_stl->inputs_count.emplace_back(values.size());
+  task_data_stl->inputs_count.emplace_back(in_lower_limits.size());
+  task_data_stl->inputs_count.emplace_back(in_upper_limits.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+  task_data_stl->outputs_count.emplace_back(out_i.size());
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  ASSERT_EQ(test_task_stl.PreProcessing(), true);
+  ASSERT_EQ(test_task_stl.Run(), true);
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_stl, test_post_processing) {
+  // Create data
+  size_t dim = 1;
+  std::vector<double> values{0.0};
+  auto f = [](const std::vector<double> &f_values) { return std::sin(f_values[0]); };
+  std::vector<double> in_lower_limits{0};
+  std::vector<double> in_upper_limits{1};
+  double n = 10.0;
+  std::vector<double> out_i(1, 0.0);
+
+  auto f_object = std::make_unique<std::function<double(const std::vector<double> &)>>(f);
+
+  // Create task_data
+  std::shared_ptr<ppc::core::TaskData> task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(f_object.get()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+  task_data_stl->inputs_count.emplace_back(values.size());
+  task_data_stl->inputs_count.emplace_back(in_lower_limits.size());
+  task_data_stl->inputs_count.emplace_back(in_upper_limits.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+  task_data_stl->outputs_count.emplace_back(out_i.size());
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  ASSERT_EQ(test_task_stl.PreProcessing(), true);
+  ASSERT_EQ(test_task_stl.Run(), true);
+  ASSERT_EQ(test_task_stl.PostProcessing(), true);
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_stl, single_integral_one_var) {
+  // Create data
+  size_t dim = 1;
+  std::vector<double> values{0.0};
+  auto f = [](const std::vector<double> &f_values) { return f_values[0]; };
+  std::vector<double> in_lower_limits{2};
+  std::vector<double> in_upper_limits{4};
+  double n = 4002.0;
+  std::vector<double> out_i(1, 0.0);
+
+  auto f_object = std::make_unique<std::function<double(const std::vector<double> &)>>(f);
+
+  // Create task_data
+  std::shared_ptr<ppc::core::TaskData> task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(f_object.get()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+  task_data_stl->inputs_count.emplace_back(values.size());
+  task_data_stl->inputs_count.emplace_back(in_lower_limits.size());
+  task_data_stl->inputs_count.emplace_back(in_upper_limits.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+  task_data_stl->outputs_count.emplace_back(out_i.size());
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  ASSERT_EQ(test_task_stl.PreProcessing(), true);
+  ASSERT_EQ(test_task_stl.Run(), true);
+  ASSERT_EQ(test_task_stl.PostProcessing(), true);
+
+  double ref_i = 6;
+  double locality = fabs(ref_i - out_i[0]);
+  ASSERT_NEAR(locality, 0, 1);
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_stl, single_integral_two_var) {
+  // Create data
+  size_t dim = 1;
+  std::vector<double> values{0.0, 3.0};
+  auto f = [](const std::vector<double> &f_values) { return f_values[0] + f_values[1]; };
+  std::vector<double> in_lower_limits{0};
+  std::vector<double> in_upper_limits{2};
+  double n = 4000.0;
+  std::vector<double> out_i(1, 0.0);
+
+  auto f_object = std::make_unique<std::function<double(const std::vector<double> &)>>(f);
+
+  // Create task_data
+  std::shared_ptr<ppc::core::TaskData> task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(f_object.get()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+  task_data_stl->inputs_count.emplace_back(values.size());
+  task_data_stl->inputs_count.emplace_back(in_lower_limits.size());
+  task_data_stl->inputs_count.emplace_back(in_upper_limits.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+  task_data_stl->outputs_count.emplace_back(out_i.size());
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  ASSERT_EQ(test_task_stl.PreProcessing(), true);
+  ASSERT_EQ(test_task_stl.Run(), true);
+  ASSERT_EQ(test_task_stl.PostProcessing(), true);
+
+  double ref_i = 8;
+  double locality = fabs(ref_i - out_i[0]);
+  ASSERT_NEAR(locality, 0, 1);
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_stl, double_integral_two_var) {
+  // Create data
+  size_t dim = 2;
+  std::vector<double> values{0.0, 0.0};
+  auto f = [](const std::vector<double> &f_values) { return (2 * f_values[0]) + (2 * f_values[1]); };
+  std::vector<double> in_lower_limits{0, 0};
+  std::vector<double> in_upper_limits{1, 1};
+  double n = 300.0;
+  std::vector<double> out_i(1, 0.0);
+
+  auto f_object = std::make_unique<std::function<double(const std::vector<double> &)>>(f);
+
+  // Create task_data
+  std::shared_ptr<ppc::core::TaskData> task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(f_object.get()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+  task_data_stl->inputs_count.emplace_back(values.size());
+  task_data_stl->inputs_count.emplace_back(in_lower_limits.size());
+  task_data_stl->inputs_count.emplace_back(in_upper_limits.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+  task_data_stl->outputs_count.emplace_back(out_i.size());
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  ASSERT_EQ(test_task_stl.PreProcessing(), true);
+  ASSERT_EQ(test_task_stl.Run(), true);
+  ASSERT_EQ(test_task_stl.PostProcessing(), true);
+
+  double ref_i = 2.0;
+  double locality = fabs(ref_i - out_i[0]);
+  ASSERT_NEAR(locality, 0, 1);
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_stl, double_integral_one_var) {
+  // Create data
+  size_t dim = 2;
+  std::vector<double> values{-17.0, 0.0};
+  auto f = [](const std::vector<double> &f_values) { return 289 + (f_values[1] * f_values[1]); };
+  std::vector<double> in_lower_limits{-10, 3};
+  std::vector<double> in_upper_limits{10, 4};
+  double n = 405.0;
+  std::vector<double> out_i(1, 0.0);
+
+  auto f_object = std::make_unique<std::function<double(const std::vector<double> &)>>(f);
+
+  // Create task_data
+  std::shared_ptr<ppc::core::TaskData> task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(f_object.get()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+  task_data_stl->inputs_count.emplace_back(values.size());
+  task_data_stl->inputs_count.emplace_back(in_lower_limits.size());
+  task_data_stl->inputs_count.emplace_back(in_upper_limits.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+  task_data_stl->outputs_count.emplace_back(out_i.size());
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  ASSERT_EQ(test_task_stl.PreProcessing(), true);
+  ASSERT_EQ(test_task_stl.Run(), true);
+  ASSERT_EQ(test_task_stl.PostProcessing(), true);
+
+  double ref_i = 6027;
+  double locality = fabs(ref_i - out_i[0]);
+  ASSERT_NEAR(locality, 0, 1);
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_stl, triple_integral_three_var) {
+  // Create data
+  size_t dim = 3;
+  std::vector<double> values{0.0, 0.0, 0.0};
+  auto f = [](const std::vector<double> &f_values) {
+    return (f_values[0] * f_values[0]) + (f_values[1] * f_values[1]) + (f_values[2] * f_values[2]);
+  };
+  std::vector<double> in_lower_limits{0, 0, 0};
+  std::vector<double> in_upper_limits{1, 1, 1};
+  double n = 100.0;
+  std::vector<double> out_i(1, 0.0);
+
+  auto f_object = std::make_unique<std::function<double(const std::vector<double> &)>>(f);
+
+  // Create task_data
+  std::shared_ptr<ppc::core::TaskData> task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(f_object.get()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+  task_data_stl->inputs_count.emplace_back(values.size());
+  task_data_stl->inputs_count.emplace_back(in_lower_limits.size());
+  task_data_stl->inputs_count.emplace_back(in_upper_limits.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+  task_data_stl->outputs_count.emplace_back(out_i.size());
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  ASSERT_EQ(test_task_stl.PreProcessing(), true);
+  ASSERT_EQ(test_task_stl.Run(), true);
+  ASSERT_EQ(test_task_stl.PostProcessing(), true);
+
+  double ref_i = 1;
+  double locality = fabs(ref_i - out_i[0]);
+  ASSERT_NEAR(locality, 0, 1);
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_stl, triple_integral_two_var) {
+  // Create data
+  size_t dim = 3;
+  std::vector<double> values{0.0, 5.0, 0.0};
+  auto f = [](const std::vector<double> &f_values) { return (f_values[0] + f_values[1]); };
+  std::vector<double> in_lower_limits{0, 0, 0};
+  std::vector<double> in_upper_limits{2, 2, 1};
+  double n = 120.0;
+  std::vector<double> out_i(1, 0.0);
+
+  auto f_object = std::make_unique<std::function<double(const std::vector<double> &)>>(f);
+
+  // Create task_data
+  std::shared_ptr<ppc::core::TaskData> task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(f_object.get()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+  task_data_stl->inputs_count.emplace_back(values.size());
+  task_data_stl->inputs_count.emplace_back(in_lower_limits.size());
+  task_data_stl->inputs_count.emplace_back(in_upper_limits.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+  task_data_stl->outputs_count.emplace_back(out_i.size());
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  ASSERT_EQ(test_task_stl.PreProcessing(), true);
+  ASSERT_EQ(test_task_stl.Run(), true);
+  ASSERT_EQ(test_task_stl.PostProcessing(), true);
+
+  double ref_i = 8;
+  double locality = fabs(ref_i - out_i[0]);
+  ASSERT_NEAR(locality, 0, 1);
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_stl, triple_integral_one_var) {
+  // Create data
+  size_t dim = 3;
+  std::vector<double> values{0.0, 5.0, -10.0};
+  auto f = [](const std::vector<double> &f_values) { return f_values[0] + 5.0 + (-10.0); };
+  std::vector<double> in_lower_limits{0, 0, 0};
+  std::vector<double> in_upper_limits{2, 1, 3};
+  double n = 100.0;
+  std::vector<double> out_i(1, 0.0);
+
+  auto f_object = std::make_unique<std::function<double(const std::vector<double> &)>>(f);
+
+  // Create task_data
+  std::shared_ptr<ppc::core::TaskData> task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(f_object.get()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+  task_data_stl->inputs_count.emplace_back(values.size());
+  task_data_stl->inputs_count.emplace_back(in_lower_limits.size());
+  task_data_stl->inputs_count.emplace_back(in_upper_limits.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+  task_data_stl->outputs_count.emplace_back(out_i.size());
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL test_task_stl(task_data_stl);
+  ASSERT_EQ(test_task_stl.Validation(), true);
+  ASSERT_EQ(test_task_stl.PreProcessing(), true);
+  ASSERT_EQ(test_task_stl.Run(), true);
+  ASSERT_EQ(test_task_stl.PostProcessing(), true);
+
+  double ref_i = -24;
+  ASSERT_EQ(ref_i, std::round(out_i[0]));
+}

--- a/tasks/stl/kholin_k_multidimensional_integrals_rectangle/func_tests/main.cpp
+++ b/tasks/stl/kholin_k_multidimensional_integrals_rectangle/func_tests/main.cpp
@@ -301,7 +301,7 @@ TEST(kholin_k_multidimensional_integrals_rectangle_stl, triple_integral_three_va
   };
   std::vector<double> in_lower_limits{0, 0, 0};
   std::vector<double> in_upper_limits{1, 1, 1};
-  double n = 100.0;
+  double n = 10.0;
   std::vector<double> out_i(1, 0.0);
 
   auto f_object = std::make_unique<std::function<double(const std::vector<double> &)>>(f);
@@ -339,7 +339,7 @@ TEST(kholin_k_multidimensional_integrals_rectangle_stl, triple_integral_two_var)
   auto f = [](const std::vector<double> &f_values) { return (f_values[0] + f_values[1]); };
   std::vector<double> in_lower_limits{0, 0, 0};
   std::vector<double> in_upper_limits{2, 2, 1};
-  double n = 120.0;
+  double n = 10.0;
   std::vector<double> out_i(1, 0.0);
 
   auto f_object = std::make_unique<std::function<double(const std::vector<double> &)>>(f);
@@ -377,7 +377,7 @@ TEST(kholin_k_multidimensional_integrals_rectangle_stl, triple_integral_one_var)
   auto f = [](const std::vector<double> &f_values) { return f_values[0] + 5.0 + (-10.0); };
   std::vector<double> in_lower_limits{0, 0, 0};
   std::vector<double> in_upper_limits{2, 1, 3};
-  double n = 100.0;
+  double n = 10.0;
   std::vector<double> out_i(1, 0.0);
 
   auto f_object = std::make_unique<std::function<double(const std::vector<double> &)>>(f);

--- a/tasks/stl/kholin_k_multidimensional_integrals_rectangle/func_tests/main.cpp
+++ b/tasks/stl/kholin_k_multidimensional_integrals_rectangle/func_tests/main.cpp
@@ -8,7 +8,6 @@
 #include <vector>
 
 #include "core/task/include/task.hpp"
-#include "core/util/include/util.hpp"
 #include "stl/kholin_k_multidimensional_integrals_rectangle/include/ops_stl.hpp"
 
 TEST(kholin_k_multidimensional_integrals_rectangle_stl, test_validation) {

--- a/tasks/stl/kholin_k_multidimensional_integrals_rectangle/include/ops_stl.hpp
+++ b/tasks/stl/kholin_k_multidimensional_integrals_rectangle/include/ops_stl.hpp
@@ -1,0 +1,44 @@
+#pragma once
+
+#include <functional>
+#include <thread>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kholin_k_multidimensional_integrals_rectangle_stl {
+using Function = std::function<double(const std::vector<double>&)>;
+class TestTaskSTL : public ppc::core::Task {
+ public:
+  explicit TestTaskSTL(ppc::core::TaskDataPtr task_data) : Task(std::move(task_data)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+
+ private:
+  std::vector<double> f_values_;
+  Function f_;
+  std::vector<double> lower_limits_;
+  std::vector<double> upper_limits_;
+  double start_n_;
+  double result_;
+  int count_level_par_;
+
+  size_t dim_;
+  size_t sz_values_;
+  size_t sz_lower_limits_;
+  size_t sz_upper_limits_;
+
+  double Integrate(const Function& f, const std::vector<double>& l_limits, const std::vector<double>& u_limits,
+                   const std::vector<double>& h, std::vector<double> f_values, int curr_index_dim, size_t dim,
+                   double n);
+  double IntegrateWithRectangleMethod(const Function& f, std::vector<double>& f_values,
+                                      const std::vector<double>& l_limits, const std::vector<double>& u_limits,
+                                      size_t dim, double n, std::vector<double> h);
+  double RunMultistepSchemeMethodRectangle(const Function& f, std::vector<double> f_values,
+                                           const std::vector<double>& l_limits, const std::vector<double>& u_limits,
+                                           size_t dim, double n);
+};
+}  // namespace kholin_k_multidimensional_integrals_rectangle_stl

--- a/tasks/stl/kholin_k_multidimensional_integrals_rectangle/include/ops_stl.hpp
+++ b/tasks/stl/kholin_k_multidimensional_integrals_rectangle/include/ops_stl.hpp
@@ -1,7 +1,7 @@
 #pragma once
 
+#include <cstddef>
 #include <functional>
-#include <thread>
 #include <utility>
 #include <vector>
 

--- a/tasks/stl/kholin_k_multidimensional_integrals_rectangle/perf_tests/main.cpp
+++ b/tasks/stl/kholin_k_multidimensional_integrals_rectangle/perf_tests/main.cpp
@@ -1,0 +1,121 @@
+#include <gtest/gtest.h>
+
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+#include "stl/kholin_k_multidimensional_integrals_rectangle/include/ops_stl.hpp"
+
+TEST(kholin_k_multidimensional_integrals_rectangle_stl, test_pipeline_run) {
+  // Create data
+  size_t dim = 3;
+  std::vector<double> values{0.0, 0.0, 0.0};
+  auto f = [](const std::vector<double> &f_values) {
+    return std::cos((f_values[0] * f_values[0]) + (f_values[1] * f_values[1]) + (f_values[2] * f_values[2])) *
+           (1 + (f_values[0] * f_values[0]) + (f_values[1] * f_values[1]) + (f_values[2] * f_values[2]));
+  };
+  std::vector<double> in_lower_limits{-1, 2, -3};
+  std::vector<double> in_upper_limits{8, 8, 2};
+  double n = 150.0;
+  std::vector<double> out_i(1, 0.0);
+
+  auto f_object = std::make_unique<std::function<double(const std::vector<double> &)>>(f);
+
+  // Create task_data
+  std::shared_ptr<ppc::core::TaskData> task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(f_object.get()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+  task_data_stl->inputs_count.emplace_back(values.size());
+  task_data_stl->inputs_count.emplace_back(in_lower_limits.size());
+  task_data_stl->inputs_count.emplace_back(in_upper_limits.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+  task_data_stl->outputs_count.emplace_back(out_i.size());
+
+  // Create Task
+  auto test_task_stl = std::make_shared<kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL>(task_data_stl);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_stl);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  double ref_i = 12;
+  double locality = fabs(ref_i - out_i[0]);
+  ASSERT_NEAR(locality, 0, 1);
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_stl, test_task_run) {
+  // Create data
+  size_t dim = 3;
+  std::vector<double> values{0.0, 0.0, 0.0};
+  auto f = [](const std::vector<double> &f_values) {
+    return std::cos((f_values[0] * f_values[0]) + (f_values[1] * f_values[1]) + (f_values[2] * f_values[2])) *
+           (1 + (f_values[0] * f_values[0]) + (f_values[1] * f_values[1]) + (f_values[2] * f_values[2]));
+  };
+  std::vector<double> in_lower_limits{-1, 2, -3};
+  std::vector<double> in_upper_limits{8, 8, 2};
+  double n = 150.0;
+  std::vector<double> out_i(1, 0.0);
+
+  auto f_object = std::make_unique<std::function<double(const std::vector<double> &)>>(f);
+
+  // Create task_data
+  std::shared_ptr<ppc::core::TaskData> task_data_stl = std::make_shared<ppc::core::TaskData>();
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(f_object.get()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+  task_data_stl->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+  task_data_stl->inputs_count.emplace_back(values.size());
+  task_data_stl->inputs_count.emplace_back(in_lower_limits.size());
+  task_data_stl->inputs_count.emplace_back(in_upper_limits.size());
+  task_data_stl->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+  task_data_stl->outputs_count.emplace_back(out_i.size());
+
+  // Create Task
+  auto test_task_stl = std::make_shared<kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL>(task_data_stl);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_stl);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  ppc::core::Perf::PrintPerfStatistic(perf_results);
+  double ref_i = 12;
+  double locality = fabs(ref_i - out_i[0]);
+  ASSERT_NEAR(locality, 0, 1);
+}

--- a/tasks/stl/kholin_k_multidimensional_integrals_rectangle/src/ops_stl.cpp
+++ b/tasks/stl/kholin_k_multidimensional_integrals_rectangle/src/ops_stl.cpp
@@ -1,0 +1,119 @@
+#include "stl/kholin_k_multidimensional_integrals_rectangle/include/ops_stl.hpp"
+
+#include <functional>
+#include <future>
+#include <thread>
+#include <vector>
+
+#include "core/util/include/util.hpp"
+
+double kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL::Integrate(
+    const Function& f, const std::vector<double>& l_limits, const std::vector<double>& u_limits,
+    const std::vector<double>& h, std::vector<double> f_values, int curr_index_dim, size_t dim, double n) {
+  const int total_steps = static_cast<int>(n);
+  double sum = 0.0;
+
+  if (curr_index_dim == static_cast<int>(dim)) {
+    return f(f_values);
+  }
+
+  if (curr_index_dim < count_level_par_) {
+    const int num_threads = ppc::util::GetPPCNumThreads();
+    const int tasks_per_thread = (total_steps + num_threads - 1) / num_threads;
+
+    std::vector<std::future<double>> futures;
+    for (int t = 0; t < num_threads; ++t) {
+      int start = t * tasks_per_thread;
+      int end = std::min(start + tasks_per_thread, total_steps);
+
+      if (start >= end) continue;
+
+      futures.emplace_back(std::async(std::launch::async, [=, &f, &l_limits, &u_limits, &h]() {
+        double local_sum = 0.0;
+        std::vector<double> local_f_values = f_values;
+
+        for (int i = start; i < end; ++i) {
+          local_f_values[curr_index_dim] =
+              l_limits[curr_index_dim] + (static_cast<double>(i) + 0.5) * h[curr_index_dim];
+          local_sum += Integrate(f, l_limits, u_limits, h, local_f_values, curr_index_dim + 1, dim, n);
+        }
+        return local_sum;
+      }));
+    }
+
+    for (auto& future : futures) {
+      sum += future.get();
+    }
+  } else {
+    for (int i = 0; i < total_steps; ++i) {
+      f_values[curr_index_dim] = l_limits[curr_index_dim] + (static_cast<double>(i) + 0.5) * h[curr_index_dim];
+      sum += Integrate(f, l_limits, u_limits, h, f_values, curr_index_dim + 1, dim, n);
+    }
+  }
+
+  return sum * h[curr_index_dim];
+}
+
+double kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL::IntegrateWithRectangleMethod(
+    const Function& f, std::vector<double>& f_values, const std::vector<double>& l_limits,
+    const std::vector<double>& u_limits, size_t dim, double n, std::vector<double> h) {
+  for (size_t i = 0; i < dim; ++i) {
+    h[i] = (u_limits[i] - l_limits[i]) / n;
+  }
+
+  return Integrate(f, l_limits, u_limits, h, f_values, 0, dim, n);
+}
+
+double kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL::RunMultistepSchemeMethodRectangle(
+    const Function& f, std::vector<double> f_values, const std::vector<double>& l_limits,
+    const std::vector<double>& u_limits, size_t dim, double n) {
+  std::vector<double> h(dim);
+  double i_n = 0.0;
+
+  i_n = IntegrateWithRectangleMethod(f, f_values, l_limits, u_limits, dim, n, h);
+  return i_n;
+}
+
+bool kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL::PreProcessingImpl() {
+  // Init value for input and output
+  sz_values_ = task_data->inputs_count[0];
+  sz_lower_limits_ = task_data->inputs_count[1];
+  sz_upper_limits_ = task_data->inputs_count[2];
+
+  auto* ptr_dim = reinterpret_cast<size_t*>(task_data->inputs[0]);
+  dim_ = *ptr_dim;
+
+  auto* ptr_f_values = reinterpret_cast<double*>(task_data->inputs[1]);
+  f_values_.assign(ptr_f_values, ptr_f_values + sz_values_);
+
+  auto* ptr_f = reinterpret_cast<std::function<double(const std::vector<double>&)>*>(task_data->inputs[2]);
+  f_ = *ptr_f;
+
+  auto* ptr_lower_limits = reinterpret_cast<double*>(task_data->inputs[3]);
+  lower_limits_.assign(ptr_lower_limits, ptr_lower_limits + sz_lower_limits_);
+
+  auto* ptr_upper_limits = reinterpret_cast<double*>(task_data->inputs[4]);
+  upper_limits_.assign(ptr_upper_limits, ptr_upper_limits + sz_upper_limits_);
+
+  auto* ptr_start_n = reinterpret_cast<double*>(task_data->inputs[5]);
+  start_n_ = *ptr_start_n;
+
+  result_ = 0.0;
+  count_level_par_ = 1;
+  return true;
+}
+
+bool kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL::ValidationImpl() {
+  // Check equality of counts elements
+  return task_data->inputs_count[1] > 0U && task_data->inputs_count[2] > 0U;
+}
+
+bool kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL::RunImpl() {
+  result_ = RunMultistepSchemeMethodRectangle(f_, f_values_, lower_limits_, upper_limits_, dim_, start_n_);
+  return true;
+}
+
+bool kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL::PostProcessingImpl() {
+  reinterpret_cast<double*>(task_data->outputs[0])[0] = result_;
+  return true;
+}

--- a/tasks/stl/kholin_k_multidimensional_integrals_rectangle/src/ops_stl.cpp
+++ b/tasks/stl/kholin_k_multidimensional_integrals_rectangle/src/ops_stl.cpp
@@ -1,8 +1,8 @@
 #include "stl/kholin_k_multidimensional_integrals_rectangle/include/ops_stl.hpp"
 
 #include <algorithm>
+#include <cstddef>
 #include <functional>
-#include <future>
 #include <thread>
 #include <vector>
 

--- a/tasks/stl/kholin_k_multidimensional_integrals_rectangle/src/ops_stl.cpp
+++ b/tasks/stl/kholin_k_multidimensional_integrals_rectangle/src/ops_stl.cpp
@@ -27,7 +27,7 @@ double kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL::Integrate
     const int remainder = total_steps % num_threads;
 
     for (int t = 0; t < num_threads; ++t) {
-      const int start = t * base_steps + (t < remainder ? t : remainder);
+      const int start = (t * base_steps) + (t < remainder ? t : remainder);
       const int end = start + base_steps + (t < remainder ? 1 : 0);
 
       threads[t] = std::thread([&, start, end, t]() {
@@ -42,7 +42,9 @@ double kholin_k_multidimensional_integrals_rectangle_stl::TestTaskSTL::Integrate
     }
 
     for (auto& th : threads) {
-      if (th.joinable()) th.join();
+      if (th.joinable()) {
+        th.join();
+      }
     }
     sum = std::accumulate(thread_sums.begin(), thread_sums.end(), 0.0) * h[0];
   } else {


### PR DESCRIPTION
**ПОСТАНОВКА ЗАДАЧИ ДЛЯ ОДНОМЕРНОГО ИНТЕГРАЛА**
Необходимо вычислить определённый интеграл на отрезке ([a, b]). Этот
отрезок разбивается на (n) равных частей, где длина каждой части
определяется как

$$ h = \frac{b - a}{n}. $$

b и a - конец и начала отрезка. Вместо b и а подставляются пределы
интегрирования, n - число шагов.

Обозначим через $$f\left(x_{i-1} + \frac{h}{2}\right)$$ значение функции
в середине каждого частичного отрезка. Затем составим сумму произведений
всех таких значений $$f\left(x_{i-1} + \frac{h}{2}\right)$$ на h — шаг
отрезка. Полученная сумма будет представлять собой приближённое значение
определённого интеграла на отрезке ([a, b]) по формуле средних
прямоугольников:

$$ \int_{a}^{b} f(x) , dx \approx h \sum_{i=1}^{n} f\left(x_{i-1} +
\frac{h}{2}\right) = h \sum_{i=1}^{n} f\left(x_{i} - \frac{h}{2}\right).
$$

**ПОСТАНОВКА ЗАДАЧИ ДЛЯ МНОГОМЕРНОГО ИНТЕГРАЛА**
Задача аналогичная задаче одномерного случая. n-мерная область
разбивается на равные части. по каждому измерению. Выбираем центр каждой
части по каждому измерению. Шаг по каждому измерению вычисляется как

$$ h = \frac{b - a}{n}. $$

b и a - конец и начала отрезка. Вместо b и а подставляются пределы
интегрирования по каждому измерению соответственно, n - число шагов.

Общая формула для d-мерного интеграла:
Δx = (b - a) / n = h

$$I \approx \sum_{i_1=1}^n \sum_{i_2=1}^n \dots \sum_{i_d=1}^n
f(x_{i_1}, x_{i_2}, \dots, x_{i_d}) \cdot (\Delta x)^d,$$

где

$$x_{i_k} = a + (i_k - \frac{1}{2}) \cdot \Delta x, \ k = 1, \dots, d.$$

**ОПИСАНИЕ РЕШЕНИЯ**
_[STL ТЕХНОЛОГИЯ]_

_СУТЬ ОПИСАНИЯ РЕШЕНИЯ_ 
Достаточно выполнить распараллеливание цикла на первом уровне рекурсии внутри метода, отвечающего за интегрирование функции. Дальнейшее распараллеливание на уровнях ниже нецелесообразно, поскольку сильно усложнит реализацию(например, использование Threadpool) или приведёт к большим накладным расходам по созданию задач и новых потоков для них. Как и в TBB версии создать пул потоков и для каждого потока распределить число шагов равномерно. Каждый поток посчитает свою частичную сумму с распределённым числом шагов. После того, как основной поток "дождётся" остальных потоков, все частичные суммы будут сложены с помощью std::accumulate. Полученный результат умножается на шаг h.

_ЭФФЕКТИВНОСТЬ_
Если интегральную сумму будут вычислять не один поток  ,а несколько, то скорость выполнения программы
должна быть увеличена. Каждый поток независимо от других вычисляет частичную интегральную сумму. Все суммы от потоков по итогу будут сложены в одну, что эффективно в плане вычислений.


**СПИСОК ИЗМЕНЕНИЙ**
- Убраны ненужные хедеры;
- Спецификатор лямбда-выражения захватывает поля задачи(this);