### PR TITLE
Холин Кирилл. Задача 1. Вариант 9. Технология MPI + OMP. Вычисление многомерных интегралов с использованием многошаговой схемы (метод прямоугольников)

### DIFF
--- a/tasks/all/kholin_k_multidimensional_integrals_rectangle/func_tests/func_all.cpp
+++ b/tasks/all/kholin_k_multidimensional_integrals_rectangle/func_tests/func_all.cpp
@@ -1,0 +1,434 @@
+#include <gtest/gtest.h>
+#include <mpi.h>
+
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <vector>
+
+#include "all/kholin_k_multidimensional_integrals_rectangle/include/ops_all.hpp"
+#include "core/task/include/task.hpp"
+
+TEST(kholin_k_multidimensional_integrals_rectangle_all, test_validation) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  // Create data
+  size_t dim = 1;
+  std::vector<double> values{0.0};
+  auto f = [](const std::vector<double> &f_values) { return std::sin(f_values[0]); };
+  std::vector<double> in_lower_limits{0};
+  std::vector<double> in_upper_limits{1};
+  double n = 10.0;
+  std::vector<double> out_i(1, 0.0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_all = std::make_shared<ppc::core::TaskData>();
+  if (rank == 0) {
+    // Create task_data
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+    task_data_all->inputs_count.emplace_back(values.size());
+    task_data_all->inputs_count.emplace_back(in_lower_limits.size());
+    task_data_all->inputs_count.emplace_back(in_upper_limits.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+    task_data_all->outputs_count.emplace_back(out_i.size());
+  }
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL test_task_all(task_data_all, f);
+  ASSERT_EQ(test_task_all.Validation(), true);
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_all, test_pre_processing) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  // Create data
+  size_t dim = 1;
+  std::vector<double> values{0.0};
+  auto f = [](const std::vector<double> &f_values) { return std::sin(f_values[0]); };
+  std::vector<double> in_lower_limits{0};
+  std::vector<double> in_upper_limits{1};
+  double n = 10.0;
+  std::vector<double> out_i(1, 0.0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_all = std::make_shared<ppc::core::TaskData>();
+  // Create task_data
+  if (rank == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+    task_data_all->inputs_count.emplace_back(values.size());
+    task_data_all->inputs_count.emplace_back(in_lower_limits.size());
+    task_data_all->inputs_count.emplace_back(in_upper_limits.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+    task_data_all->outputs_count.emplace_back(out_i.size());
+  }
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL test_task_all(task_data_all, f);
+  ASSERT_EQ(test_task_all.Validation(), true);
+  ASSERT_EQ(test_task_all.PreProcessing(), true);
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_all, test_run) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  // Create data
+  size_t dim = 1;
+  std::vector<double> values{0.0};
+  auto f = [](const std::vector<double> &f_values) { return std::sin(f_values[0]); };
+  std::vector<double> in_lower_limits{0};
+  std::vector<double> in_upper_limits{1};
+  double n = 10.0;
+  std::vector<double> out_i(1, 0.0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_all = std::make_shared<ppc::core::TaskData>();
+  // Create task_data
+  if (rank == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+    task_data_all->inputs_count.emplace_back(values.size());
+    task_data_all->inputs_count.emplace_back(in_lower_limits.size());
+    task_data_all->inputs_count.emplace_back(in_upper_limits.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+    task_data_all->outputs_count.emplace_back(out_i.size());
+  }
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL test_task_all(task_data_all, f);
+  ASSERT_EQ(test_task_all.Validation(), true);
+  ASSERT_EQ(test_task_all.PreProcessing(), true);
+  ASSERT_EQ(test_task_all.Run(), true);
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_all, test_post_processing) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  // Create data
+  size_t dim = 1;
+  std::vector<double> values{0.0};
+  auto f = [](const std::vector<double> &f_values) { return std::sin(f_values[0]); };
+  std::vector<double> in_lower_limits{0};
+  std::vector<double> in_upper_limits{1};
+  double n = 10.0;
+  std::vector<double> out_i(1, 0.0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_all = std::make_shared<ppc::core::TaskData>();
+  // Create task_data
+  if (rank == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+    task_data_all->inputs_count.emplace_back(values.size());
+    task_data_all->inputs_count.emplace_back(in_lower_limits.size());
+    task_data_all->inputs_count.emplace_back(in_upper_limits.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+    task_data_all->outputs_count.emplace_back(out_i.size());
+  }
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL test_task_all(task_data_all, f);
+  ASSERT_EQ(test_task_all.Validation(), true);
+  ASSERT_EQ(test_task_all.PreProcessing(), true);
+  ASSERT_EQ(test_task_all.Run(), true);
+  ASSERT_EQ(test_task_all.PostProcessing(), true);
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_all, single_integral_one_var) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  // Create data
+  size_t dim = 1;
+  std::vector<double> values{0.0};
+  auto f = [](const std::vector<double> &f_values) { return f_values[0]; };
+  std::vector<double> in_lower_limits{2};
+  std::vector<double> in_upper_limits{4};
+  double n = 4002.0;
+  std::vector<double> out_i(1, 0.0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_all = std::make_shared<ppc::core::TaskData>();
+  // Create task_data
+  if (rank == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+    task_data_all->inputs_count.emplace_back(values.size());
+    task_data_all->inputs_count.emplace_back(in_lower_limits.size());
+    task_data_all->inputs_count.emplace_back(in_upper_limits.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+    task_data_all->outputs_count.emplace_back(out_i.size());
+  }
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL test_task_all(task_data_all, f);
+  ASSERT_EQ(test_task_all.Validation(), true);
+  ASSERT_EQ(test_task_all.PreProcessing(), true);
+  ASSERT_EQ(test_task_all.Run(), true);
+  ASSERT_EQ(test_task_all.PostProcessing(), true);
+
+  if (rank == 0) {
+    double ref_i = 6;
+    ASSERT_EQ(ref_i, std::round(out_i[0]));
+  }
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_all, single_integral_two_var) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  // Create data
+  size_t dim = 1;
+  std::vector<double> values{0.0, 3.0};
+  auto f = [](const std::vector<double> &f_values) { return f_values[0] + f_values[1]; };
+  std::vector<double> in_lower_limits{0};
+  std::vector<double> in_upper_limits{2};
+  double n = 4000.0;
+  std::vector<double> out_i(1, 0.0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_all = std::make_shared<ppc::core::TaskData>();
+  // Create task_data
+  if (rank == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+    task_data_all->inputs_count.emplace_back(values.size());
+    task_data_all->inputs_count.emplace_back(in_lower_limits.size());
+    task_data_all->inputs_count.emplace_back(in_upper_limits.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+    task_data_all->outputs_count.emplace_back(out_i.size());
+  }
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL test_task_all(task_data_all, f);
+  ASSERT_EQ(test_task_all.Validation(), true);
+  ASSERT_EQ(test_task_all.PreProcessing(), true);
+  ASSERT_EQ(test_task_all.Run(), true);
+  ASSERT_EQ(test_task_all.PostProcessing(), true);
+
+  if (rank == 0) {
+    double ref_i = 8;
+    double locality = fabs(ref_i - out_i[0]);
+    ASSERT_NEAR(locality, 0, 1);
+  }
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_all, double_integral_two_var) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  // Create data
+  size_t dim = 2;
+  std::vector<double> values{0.0, 0.0};
+  auto f = [](const std::vector<double> &f_values) { return (2 * f_values[0]) + (2 * f_values[1]); };
+  std::vector<double> in_lower_limits{0, 0};
+  std::vector<double> in_upper_limits{1, 1};
+  double n = 300.0;
+  std::vector<double> out_i(1, 0.0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_all = std::make_shared<ppc::core::TaskData>();
+  // Create task_data
+  if (rank == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+    task_data_all->inputs_count.emplace_back(values.size());
+    task_data_all->inputs_count.emplace_back(in_lower_limits.size());
+    task_data_all->inputs_count.emplace_back(in_upper_limits.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+    task_data_all->outputs_count.emplace_back(out_i.size());
+  }
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL test_task_all(task_data_all, f);
+  ASSERT_EQ(test_task_all.Validation(), true);
+  ASSERT_EQ(test_task_all.PreProcessing(), true);
+  ASSERT_EQ(test_task_all.Run(), true);
+  ASSERT_EQ(test_task_all.PostProcessing(), true);
+
+  if (rank == 0) {
+    double ref_i = 2.0;
+    double locality = fabs(ref_i - out_i[0]);
+    ASSERT_NEAR(locality, 0, 1);
+  }
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_all, double_integral_one_var) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  // Create data
+  size_t dim = 2;
+  std::vector<double> values{-17.0, 0.0};
+  auto f = [](const std::vector<double> &f_values) { return 289 + (f_values[1] * f_values[1]); };
+  std::vector<double> in_lower_limits{-10, 3};
+  std::vector<double> in_upper_limits{10, 4};
+  double n = 405.0;
+  std::vector<double> out_i(1, 0.0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_all = std::make_shared<ppc::core::TaskData>();
+  // Create task_data
+  if (rank == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+    task_data_all->inputs_count.emplace_back(values.size());
+    task_data_all->inputs_count.emplace_back(in_lower_limits.size());
+    task_data_all->inputs_count.emplace_back(in_upper_limits.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+    task_data_all->outputs_count.emplace_back(out_i.size());
+  }
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL test_task_all(task_data_all, f);
+  ASSERT_EQ(test_task_all.Validation(), true);
+  ASSERT_EQ(test_task_all.PreProcessing(), true);
+  ASSERT_EQ(test_task_all.Run(), true);
+  ASSERT_EQ(test_task_all.PostProcessing(), true);
+
+  if (rank == 0) {
+    double ref_i = 6027;
+    double locality = fabs(ref_i - out_i[0]);
+    ASSERT_NEAR(locality, 0, 1);
+  }
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_all, triple_integral_three_var) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  // Create data
+  size_t dim = 3;
+  std::vector<double> values{0.0, 0.0, 0.0};
+  auto f = [](const std::vector<double> &f_values) {
+    return (f_values[0] * f_values[0]) + (f_values[1] * f_values[1]) + (f_values[2] * f_values[2]);
+  };
+  std::vector<double> in_lower_limits{0, 0, 0};
+  std::vector<double> in_upper_limits{1, 1, 1};
+  double n = 100.0;
+  std::vector<double> out_i(1, 0.0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_all = std::make_shared<ppc::core::TaskData>();
+  // Create task_data
+  if (rank == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+    task_data_all->inputs_count.emplace_back(values.size());
+    task_data_all->inputs_count.emplace_back(in_lower_limits.size());
+    task_data_all->inputs_count.emplace_back(in_upper_limits.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+    task_data_all->outputs_count.emplace_back(out_i.size());
+  }
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL test_task_all(task_data_all, f);
+  ASSERT_EQ(test_task_all.Validation(), true);
+  ASSERT_EQ(test_task_all.PreProcessing(), true);
+  ASSERT_EQ(test_task_all.Run(), true);
+  ASSERT_EQ(test_task_all.PostProcessing(), true);
+
+  if (rank == 0) {
+    double ref_i = 1;
+    double locality = fabs(ref_i - out_i[0]);
+    ASSERT_NEAR(locality, 0, 1);
+  }
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_all, triple_integral_two_var) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  // Create data
+  size_t dim = 3;
+  std::vector<double> values{0.0, 5.0, 0.0};
+  auto f = [](const std::vector<double> &f_values) { return (f_values[0] + f_values[1]); };
+  std::vector<double> in_lower_limits{0, 0, 0};
+  std::vector<double> in_upper_limits{2, 2, 1};
+  double n = 120.0;
+  std::vector<double> out_i(1, 0.0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_all = std::make_shared<ppc::core::TaskData>();
+  // Create task_data
+  if (rank == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+    task_data_all->inputs_count.emplace_back(values.size());
+    task_data_all->inputs_count.emplace_back(in_lower_limits.size());
+    task_data_all->inputs_count.emplace_back(in_upper_limits.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+    task_data_all->outputs_count.emplace_back(out_i.size());
+  }
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL test_task_all(task_data_all, f);
+  ASSERT_EQ(test_task_all.Validation(), true);
+  ASSERT_EQ(test_task_all.PreProcessing(), true);
+  ASSERT_EQ(test_task_all.Run(), true);
+  ASSERT_EQ(test_task_all.PostProcessing(), true);
+
+  if (rank == 0) {
+    double ref_i = 8;
+    double locality = fabs(ref_i - out_i[0]);
+    ASSERT_NEAR(locality, 0, 1);
+  }
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_all, triple_integral_one_var) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  // Create data
+  size_t dim = 3;
+  std::vector<double> values{0.0, 5.0, -10.0};
+  auto f = [](const std::vector<double> &f_values) { return f_values[0] + 5.0 + (-10.0); };
+  std::vector<double> in_lower_limits{0, 0, 0};
+  std::vector<double> in_upper_limits{2, 1, 3};
+  double n = 100.0;
+  std::vector<double> out_i(1, 0.0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_all = std::make_shared<ppc::core::TaskData>();
+  // Create task_data
+  if (rank == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+    task_data_all->inputs_count.emplace_back(values.size());
+    task_data_all->inputs_count.emplace_back(in_lower_limits.size());
+    task_data_all->inputs_count.emplace_back(in_upper_limits.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+    task_data_all->outputs_count.emplace_back(out_i.size());
+  }
+
+  // Create Task
+  kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL test_task_all(task_data_all, f);
+  ASSERT_EQ(test_task_all.Validation(), true);
+  ASSERT_EQ(test_task_all.PreProcessing(), true);
+  ASSERT_EQ(test_task_all.Run(), true);
+  ASSERT_EQ(test_task_all.PostProcessing(), true);
+
+  if (rank == 0) {
+    double ref_i = -24;
+    double locality = fabs(ref_i - out_i[0]);
+    ASSERT_NEAR(locality, 0, 1);
+  }
+}

--- a/tasks/all/kholin_k_multidimensional_integrals_rectangle/func_tests/func_all.cpp
+++ b/tasks/all/kholin_k_multidimensional_integrals_rectangle/func_tests/func_all.cpp
@@ -1,5 +1,14 @@
 #include <gtest/gtest.h>
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-align"
+#endif
+
 #include <mpi.h>
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 #include <cmath>
 #include <cstddef>

--- a/tasks/all/kholin_k_multidimensional_integrals_rectangle/func_tests/func_all.cpp
+++ b/tasks/all/kholin_k_multidimensional_integrals_rectangle/func_tests/func_all.cpp
@@ -11,7 +11,6 @@
 #endif
 
 #include <cmath>
-#include <cstddef>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -24,7 +23,7 @@ TEST(kholin_k_multidimensional_integrals_rectangle_all, test_validation) {
   int rank = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   // Create data
-  size_t dim = 1;
+  int dim = 1;
   std::vector<double> values{0.0};
   auto f = [](const std::vector<double> &f_values) { return std::sin(f_values[0]); };
   std::vector<double> in_lower_limits{0};
@@ -56,7 +55,7 @@ TEST(kholin_k_multidimensional_integrals_rectangle_all, test_pre_processing) {
   int rank = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   // Create data
-  size_t dim = 1;
+  int dim = 1;
   std::vector<double> values{0.0};
   auto f = [](const std::vector<double> &f_values) { return std::sin(f_values[0]); };
   std::vector<double> in_lower_limits{0};
@@ -89,7 +88,7 @@ TEST(kholin_k_multidimensional_integrals_rectangle_all, test_run) {
   int rank = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   // Create data
-  size_t dim = 1;
+  int dim = 1;
   std::vector<double> values{0.0};
   auto f = [](const std::vector<double> &f_values) { return std::sin(f_values[0]); };
   std::vector<double> in_lower_limits{0};
@@ -123,7 +122,7 @@ TEST(kholin_k_multidimensional_integrals_rectangle_all, test_post_processing) {
   int rank = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   // Create data
-  size_t dim = 1;
+  int dim = 1;
   std::vector<double> values{0.0};
   auto f = [](const std::vector<double> &f_values) { return std::sin(f_values[0]); };
   std::vector<double> in_lower_limits{0};
@@ -158,7 +157,7 @@ TEST(kholin_k_multidimensional_integrals_rectangle_all, single_integral_one_var)
   int rank = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   // Create data
-  size_t dim = 1;
+  int dim = 1;
   std::vector<double> values{0.0};
   auto f = [](const std::vector<double> &f_values) { return f_values[0]; };
   std::vector<double> in_lower_limits{2};
@@ -198,7 +197,7 @@ TEST(kholin_k_multidimensional_integrals_rectangle_all, single_integral_two_var)
   int rank = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   // Create data
-  size_t dim = 1;
+  int dim = 1;
   std::vector<double> values{0.0, 3.0};
   auto f = [](const std::vector<double> &f_values) { return f_values[0] + f_values[1]; };
   std::vector<double> in_lower_limits{0};
@@ -239,7 +238,7 @@ TEST(kholin_k_multidimensional_integrals_rectangle_all, double_integral_two_var)
   int rank = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   // Create data
-  size_t dim = 2;
+  int dim = 2;
   std::vector<double> values{0.0, 0.0};
   auto f = [](const std::vector<double> &f_values) { return (2 * f_values[0]) + (2 * f_values[1]); };
   std::vector<double> in_lower_limits{0, 0};
@@ -280,7 +279,7 @@ TEST(kholin_k_multidimensional_integrals_rectangle_all, double_integral_one_var)
   int rank = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   // Create data
-  size_t dim = 2;
+  int dim = 2;
   std::vector<double> values{-17.0, 0.0};
   auto f = [](const std::vector<double> &f_values) { return 289 + (f_values[1] * f_values[1]); };
   std::vector<double> in_lower_limits{-10, 3};
@@ -321,7 +320,7 @@ TEST(kholin_k_multidimensional_integrals_rectangle_all, triple_integral_three_va
   int rank = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   // Create data
-  size_t dim = 3;
+  int dim = 3;
   std::vector<double> values{0.0, 0.0, 0.0};
   auto f = [](const std::vector<double> &f_values) {
     return (f_values[0] * f_values[0]) + (f_values[1] * f_values[1]) + (f_values[2] * f_values[2]);
@@ -364,7 +363,7 @@ TEST(kholin_k_multidimensional_integrals_rectangle_all, triple_integral_two_var)
   int rank = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   // Create data
-  size_t dim = 3;
+  int dim = 3;
   std::vector<double> values{0.0, 5.0, 0.0};
   auto f = [](const std::vector<double> &f_values) { return (f_values[0] + f_values[1]); };
   std::vector<double> in_lower_limits{0, 0, 0};
@@ -405,7 +404,7 @@ TEST(kholin_k_multidimensional_integrals_rectangle_all, triple_integral_one_var)
   int rank = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   // Create data
-  size_t dim = 3;
+  int dim = 3;
   std::vector<double> values{0.0, 5.0, -10.0};
   auto f = [](const std::vector<double> &f_values) { return f_values[0] + 5.0 + (-10.0); };
   std::vector<double> in_lower_limits{0, 0, 0};

--- a/tasks/all/kholin_k_multidimensional_integrals_rectangle/include/ops_all.hpp
+++ b/tasks/all/kholin_k_multidimensional_integrals_rectangle/include/ops_all.hpp
@@ -38,6 +38,11 @@ class TestTaskALL : public ppc::core::Task {
   Function f_;
   std::vector<double> lower_limits_;
   std::vector<double> upper_limits_;
+
+  std::vector<double> common_f_values_;
+  std::vector<double> common_lower_limits_;
+  std::vector<double> common_upper_limits_;
+
   double start_n_;
 
   std::vector<double> local_l_limits_;

--- a/tasks/all/kholin_k_multidimensional_integrals_rectangle/include/ops_all.hpp
+++ b/tasks/all/kholin_k_multidimensional_integrals_rectangle/include/ops_all.hpp
@@ -1,0 +1,55 @@
+#pragma once
+
+#include <mpi.h>
+
+#include <boost/mpi/collectives.hpp>
+#include <cstddef>
+#include <functional>
+#include <utility>
+#include <vector>
+
+#include "core/task/include/task.hpp"
+
+namespace kholin_k_multidimensional_integrals_rectangle_all {
+using Function = std::function<double(const std::vector<double>&)>;
+class TestTaskALL : public ppc::core::Task {
+  MPI_Datatype GetMpiType();
+
+ public:
+  explicit TestTaskALL(ppc::core::TaskDataPtr task_data, std::function<double(const std::vector<double>&)> f)
+      : Task(std::move(task_data)), f_(std::move(f)) {}
+  bool PreProcessingImpl() override;
+  bool ValidationImpl() override;
+  bool RunImpl() override;
+  bool PostProcessingImpl() override;
+  ~TestTaskALL() override;
+
+ private:
+  std::vector<double> f_values_;
+  Function f_;
+  std::vector<double> lower_limits_;
+  std::vector<double> upper_limits_;
+  double start_n_;
+
+  std::vector<double> local_l_limits_;
+  std::vector<double> local_u_limits_;
+
+  size_t dim_;
+  size_t sz_values_;
+  size_t sz_lower_limits_;
+  size_t sz_upper_limits_;
+  double I_2n_;
+
+  double Integrate(const Function& f, const std::vector<double>& l_limits, const std::vector<double>& u_limits,
+                   const std::vector<double>& h, std::vector<double>& f_values, int curr_index_dim, size_t dim,
+                   double n);
+  double IntegrateWithRectangleMethod(const Function& f, std::vector<double>& f_values,
+                                      const std::vector<double>& l_limits, const std::vector<double>& u_limits,
+                                      size_t dim, double n);
+  double RunMultistepSchemeMethodRectangle(const Function& f, std::vector<double>& f_values,
+                                           const std::vector<double>& l_limits, const std::vector<double>& u_limits,
+                                           size_t dim, double n);
+  MPI_Datatype mpi_size_t_;
+};
+
+}  // namespace kholin_k_multidimensional_integrals_rectangle_all

--- a/tasks/all/kholin_k_multidimensional_integrals_rectangle/include/ops_all.hpp
+++ b/tasks/all/kholin_k_multidimensional_integrals_rectangle/include/ops_all.hpp
@@ -1,16 +1,5 @@
 #pragma once
 
-#ifdef __clang__
-#pragma clang diagnostic push
-#pragma clang diagnostic ignored "-Wcast-align"
-#endif
-
-#include <mpi.h>
-
-#ifdef __clang__
-#pragma clang diagnostic pop
-#endif
-
 #include <boost/mpi/collectives.hpp>
 #include <functional>
 #include <utility>

--- a/tasks/all/kholin_k_multidimensional_integrals_rectangle/include/ops_all.hpp
+++ b/tasks/all/kholin_k_multidimensional_integrals_rectangle/include/ops_all.hpp
@@ -12,7 +12,6 @@
 #endif
 
 #include <boost/mpi/collectives.hpp>
-#include <cstddef>
 #include <functional>
 #include <utility>
 #include <vector>
@@ -22,8 +21,6 @@
 namespace kholin_k_multidimensional_integrals_rectangle_all {
 using Function = std::function<double(const std::vector<double>&)>;
 class TestTaskALL : public ppc::core::Task {
-  MPI_Datatype GetMpiType();
-
  public:
   explicit TestTaskALL(ppc::core::TaskDataPtr task_data, std::function<double(const std::vector<double>&)> f)
       : Task(std::move(task_data)), f_(std::move(f)) {}
@@ -31,7 +28,6 @@ class TestTaskALL : public ppc::core::Task {
   bool ValidationImpl() override;
   bool RunImpl() override;
   bool PostProcessingImpl() override;
-  ~TestTaskALL() override;
 
  private:
   std::vector<double> f_values_;
@@ -39,31 +35,25 @@ class TestTaskALL : public ppc::core::Task {
   std::vector<double> lower_limits_;
   std::vector<double> upper_limits_;
 
-  std::vector<double> common_f_values_;
-  std::vector<double> common_lower_limits_;
-  std::vector<double> common_upper_limits_;
-
   double start_n_;
 
   std::vector<double> local_l_limits_;
   std::vector<double> local_u_limits_;
 
-  size_t dim_;
-  size_t sz_values_;
-  size_t sz_lower_limits_;
-  size_t sz_upper_limits_;
+  int dim_;
+  int sz_values_;
+  int sz_lower_limits_;
+  int sz_upper_limits_;
   double I_2n_;
 
   double Integrate(const Function& f, const std::vector<double>& l_limits, const std::vector<double>& u_limits,
-                   const std::vector<double>& h, std::vector<double>& f_values, int curr_index_dim, size_t dim,
-                   double n);
+                   const std::vector<double>& h, std::vector<double>& f_values, int curr_index_dim, int dim, double n);
   double IntegrateWithRectangleMethod(const Function& f, std::vector<double>& f_values,
-                                      const std::vector<double>& l_limits, const std::vector<double>& u_limits,
-                                      size_t dim, double n);
+                                      const std::vector<double>& l_limits, const std::vector<double>& u_limits, int dim,
+                                      double n);
   double RunMultistepSchemeMethodRectangle(const Function& f, std::vector<double>& f_values,
                                            const std::vector<double>& l_limits, const std::vector<double>& u_limits,
-                                           size_t dim, double n);
-  MPI_Datatype mpi_size_t_;
+                                           int dim, double n);
 };
 
 }  // namespace kholin_k_multidimensional_integrals_rectangle_all

--- a/tasks/all/kholin_k_multidimensional_integrals_rectangle/include/ops_all.hpp
+++ b/tasks/all/kholin_k_multidimensional_integrals_rectangle/include/ops_all.hpp
@@ -1,6 +1,15 @@
 #pragma once
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-align"
+#endif
+
 #include <mpi.h>
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 #include <boost/mpi/collectives.hpp>
 #include <cstddef>

--- a/tasks/all/kholin_k_multidimensional_integrals_rectangle/perf_tests/perf_all.cpp
+++ b/tasks/all/kholin_k_multidimensional_integrals_rectangle/perf_tests/perf_all.cpp
@@ -1,0 +1,136 @@
+#include <gtest/gtest.h>
+#include <mpi.h>
+
+#include <chrono>
+#include <cmath>
+#include <cstddef>
+#include <cstdint>
+#include <memory>
+#include <vector>
+
+#include "all/kholin_k_multidimensional_integrals_rectangle/include/ops_all.hpp"
+#include "boost/mpi/communicator.hpp"
+#include "core/perf/include/perf.hpp"
+#include "core/task/include/task.hpp"
+
+TEST(kholin_k_multidimensional_integrals_rectangle_all, test_pipeline_run) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  // Create data
+  size_t dim = 3;
+  std::vector<double> values{0.0, 0.0, 0.0};
+  auto f = [](const std::vector<double> &f_values) {
+    return std::cos((f_values[0] * f_values[0]) + (f_values[1] * f_values[1]) + (f_values[2] * f_values[2])) *
+           (1 + (f_values[0] * f_values[0]) + (f_values[1] * f_values[1]) + (f_values[2] * f_values[2]));
+  };
+  std::vector<double> in_lower_limits{-1, 2, -3};
+  std::vector<double> in_upper_limits{8, 8, 2};
+  double n = 150.0;
+  std::vector<double> out_i(1, 0.0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_all = std::make_shared<ppc::core::TaskData>();
+  // Create task_data
+  if (rank == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+    task_data_all->inputs_count.emplace_back(values.size());
+    task_data_all->inputs_count.emplace_back(in_lower_limits.size());
+    task_data_all->inputs_count.emplace_back(in_upper_limits.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+    task_data_all->outputs_count.emplace_back(out_i.size());
+  }
+
+  // Create Task
+  auto test_task_all =
+      std::make_shared<kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL>(task_data_all, f);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_all);
+  perf_analyzer->PipelineRun(perf_attr, perf_results);
+  if (rank == 0) {
+    double ref_i = 12;
+    double locality = fabs(ref_i - out_i[0]);
+    ASSERT_NEAR(locality, 0, 1);
+  }
+  boost::mpi::communicator world;
+  if (world.rank() == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+  }
+}
+
+TEST(kholin_k_multidimensional_integrals_rectangle_all, test_task_run) {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  // Create data
+  size_t dim = 3;
+  std::vector<double> values{0.0, 0.0, 0.0};
+  auto f = [](const std::vector<double> &f_values) {
+    return std::cos((f_values[0] * f_values[0]) + (f_values[1] * f_values[1]) + (f_values[2] * f_values[2])) *
+           (1 + (f_values[0] * f_values[0]) + (f_values[1] * f_values[1]) + (f_values[2] * f_values[2]));
+  };
+  std::vector<double> in_lower_limits{-1, 2, -3};
+  std::vector<double> in_upper_limits{8, 8, 2};
+  double n = 150.0;
+  std::vector<double> out_i(1, 0.0);
+
+  std::shared_ptr<ppc::core::TaskData> task_data_all = std::make_shared<ppc::core::TaskData>();
+  // Create task_data
+  if (rank == 0) {
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&dim));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(values.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_lower_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(in_upper_limits.data()));
+    task_data_all->inputs.emplace_back(reinterpret_cast<uint8_t *>(&n));
+    task_data_all->inputs_count.emplace_back(values.size());
+    task_data_all->inputs_count.emplace_back(in_lower_limits.size());
+    task_data_all->inputs_count.emplace_back(in_upper_limits.size());
+    task_data_all->outputs.emplace_back(reinterpret_cast<uint8_t *>(out_i.data()));
+    task_data_all->outputs_count.emplace_back(out_i.size());
+  }
+
+  // Create Task
+  auto test_task_all =
+      std::make_shared<kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL>(task_data_all, f);
+
+  // Create Perf attributes
+  auto perf_attr = std::make_shared<ppc::core::PerfAttr>();
+  perf_attr->num_running = 10;
+  const auto t0 = std::chrono::high_resolution_clock::now();
+  perf_attr->current_timer = [&] {
+    auto current_time_point = std::chrono::high_resolution_clock::now();
+    auto duration = std::chrono::duration_cast<std::chrono::nanoseconds>(current_time_point - t0).count();
+    return static_cast<double>(duration) * 1e-9;
+  };
+
+  // Create and init perf results
+  auto perf_results = std::make_shared<ppc::core::PerfResults>();
+
+  // Create Perf analyzer
+  auto perf_analyzer = std::make_shared<ppc::core::Perf>(test_task_all);
+  perf_analyzer->TaskRun(perf_attr, perf_results);
+  if (rank == 0) {
+    double ref_i = 12;
+    double locality = fabs(ref_i - out_i[0]);
+    ASSERT_NEAR(locality, 0, 1);
+  }
+  boost::mpi::communicator world;
+  if (world.rank() == 0) {
+    ppc::core::Perf::PrintPerfStatistic(perf_results);
+  }
+}

--- a/tasks/all/kholin_k_multidimensional_integrals_rectangle/perf_tests/perf_all.cpp
+++ b/tasks/all/kholin_k_multidimensional_integrals_rectangle/perf_tests/perf_all.cpp
@@ -12,7 +12,6 @@
 
 #include <chrono>
 #include <cmath>
-#include <cstddef>
 #include <cstdint>
 #include <memory>
 #include <vector>
@@ -26,7 +25,7 @@ TEST(kholin_k_multidimensional_integrals_rectangle_all, test_pipeline_run) {
   int rank = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   // Create data
-  size_t dim = 3;
+  int dim = 3;
   std::vector<double> values{0.0, 0.0, 0.0};
   auto f = [](const std::vector<double> &f_values) {
     return std::cos((f_values[0] * f_values[0]) + (f_values[1] * f_values[1]) + (f_values[2] * f_values[2])) *
@@ -87,7 +86,7 @@ TEST(kholin_k_multidimensional_integrals_rectangle_all, test_task_run) {
   int rank = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   // Create data
-  size_t dim = 3;
+  int dim = 3;
   std::vector<double> values{0.0, 0.0, 0.0};
   auto f = [](const std::vector<double> &f_values) {
     return std::cos((f_values[0] * f_values[0]) + (f_values[1] * f_values[1]) + (f_values[2] * f_values[2])) *

--- a/tasks/all/kholin_k_multidimensional_integrals_rectangle/perf_tests/perf_all.cpp
+++ b/tasks/all/kholin_k_multidimensional_integrals_rectangle/perf_tests/perf_all.cpp
@@ -1,5 +1,14 @@
 #include <gtest/gtest.h>
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-align"
+#endif
+
 #include <mpi.h>
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 
 #include <chrono>
 #include <cmath>

--- a/tasks/all/kholin_k_multidimensional_integrals_rectangle/src/ops_all.cpp
+++ b/tasks/all/kholin_k_multidimensional_integrals_rectangle/src/ops_all.cpp
@@ -14,18 +14,17 @@
 
 #include <boost/mpi/collectives.hpp>
 #include <cmath>
-#include <cstddef>
 #include <vector>
 
 double kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::Integrate(
     const Function& f, const std::vector<double>& l_limits, const std::vector<double>& u_limits,
-    const std::vector<double>& h, std::vector<double>& f_values, int curr_index_dim, size_t dim, double n) {
-  if (curr_index_dim == static_cast<int>(dim)) {
+    const std::vector<double>& h, std::vector<double>& f_values, int curr_index_dim, int dim, double n) {
+  if (curr_index_dim == dim) {
     return f(f_values);
   }
 
   double sum = 0.0;
-  for (size_t i = 0; i < static_cast<size_t>(n); ++i) {
+  for (int i = 0; i < static_cast<int>(n); ++i) {
     f_values[curr_index_dim] = l_limits[curr_index_dim] + (static_cast<double>(i) + 0.5) * h[curr_index_dim];
     sum += Integrate(f, l_limits, u_limits, h, f_values, curr_index_dim + 1, dim, n);
   }
@@ -34,10 +33,10 @@ double kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::Integrate
 
 double kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::IntegrateWithRectangleMethod(
     const Function& f, std::vector<double>& f_values, const std::vector<double>& l_limits,
-    const std::vector<double>& u_limits, size_t dim, double n) {
+    const std::vector<double>& u_limits, int dim, double n) {
   std::vector<double> h(dim);
 #pragma omp parallel for
-  for (int i = 0; i < static_cast<int>(dim); ++i) {
+  for (int i = 0; i < dim; ++i) {
     h[i] = (u_limits[i] - l_limits[i]) / n;
   }
   return Integrate(f, l_limits, u_limits, h, f_values, 0, dim, n);
@@ -45,7 +44,7 @@ double kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::Integrate
 
 double kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::RunMultistepSchemeMethodRectangle(
     const Function& f, std::vector<double>& f_values, const std::vector<double>& l_limits,
-    const std::vector<double>& u_limits, size_t dim, double n) {
+    const std::vector<double>& u_limits, int dim, double n) {
   int rank = 0;
   int size = 0;
   MPI_Comm_size(MPI_COMM_WORLD, &size);
@@ -54,7 +53,7 @@ double kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::RunMultis
     local_l_limits_ = std::vector<double>(dim);
     local_u_limits_ = std::vector<double>(dim);
   }
-  for (size_t i = 0; i < dim_; ++i) {
+  for (int i = 0; i < dim_; ++i) {
     double range = u_limits[i] - l_limits[i];
     local_l_limits_[i] = l_limits[i] + (rank * (range / size));
     local_u_limits_[i] = l_limits[i] + ((rank + 1) * (range / size));
@@ -74,11 +73,11 @@ bool kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::PreProcessi
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
   if (rank == 0) {
     // Init value for input and output
-    sz_values_ = task_data->inputs_count[0];
-    sz_lower_limits_ = task_data->inputs_count[1];
-    sz_upper_limits_ = task_data->inputs_count[2];
+    sz_values_ = static_cast<int>(task_data->inputs_count[0]);
+    sz_lower_limits_ = static_cast<int>(task_data->inputs_count[1]);
+    sz_upper_limits_ = static_cast<int>(task_data->inputs_count[2]);
 
-    auto* ptr_dim = reinterpret_cast<size_t*>(task_data->inputs[0]);
+    auto* ptr_dim = reinterpret_cast<int*>(task_data->inputs[0]);
     dim_ = *ptr_dim;
 
     auto* ptr_f_values = reinterpret_cast<double*>(task_data->inputs[1]);
@@ -99,7 +98,6 @@ bool kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::PreProcessi
 bool kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::ValidationImpl() {
   int rank = 0;
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
-  mpi_size_t_ = GetMpiType();
   if (rank == 0) {
     return task_data->inputs_count[1] > 0U && task_data->inputs_count[2] > 0U;
   }
@@ -112,27 +110,22 @@ bool kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::RunImpl() {
   MPI_Comm_size(MPI_COMM_WORLD, &size);
   MPI_Comm_rank(MPI_COMM_WORLD, &rank);
 
-  MPI_Bcast(&sz_values_, 1, mpi_size_t_, 0, MPI_COMM_WORLD);
-  MPI_Bcast(&sz_lower_limits_, 1, mpi_size_t_, 0, MPI_COMM_WORLD);
-  MPI_Bcast(&sz_upper_limits_, 1, mpi_size_t_, 0, MPI_COMM_WORLD);
-  MPI_Bcast(&dim_, 1, mpi_size_t_, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&sz_values_, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&sz_lower_limits_, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&sz_upper_limits_, 1, MPI_INT, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&dim_, 1, MPI_INT, 0, MPI_COMM_WORLD);
   MPI_Bcast(&start_n_, 1, MPI_DOUBLE, 0, MPI_COMM_WORLD);
 
-  if (rank >= 0) {
-    common_f_values_ = std::vector<double>(sz_values_);
-    common_lower_limits_ = std::vector<double>(sz_lower_limits_);
-    common_upper_limits_ = std::vector<double>(sz_upper_limits_);
-    if (rank == 0) {
-      common_f_values_.assign(f_values_.begin(), f_values_.end());
-      common_lower_limits_.assign(lower_limits_.begin(), lower_limits_.end());
-      common_upper_limits_.assign(upper_limits_.begin(), upper_limits_.end());
-    }
+  if (rank > 0) {
+    f_values_ = std::vector<double>(sz_values_);
+    lower_limits_ = std::vector<double>(sz_lower_limits_);
+    upper_limits_ = std::vector<double>(sz_upper_limits_);
   }
-  MPI_Bcast(common_lower_limits_.data(), static_cast<int>(sz_lower_limits_), MPI_DOUBLE, 0, MPI_COMM_WORLD);
-  MPI_Bcast(common_upper_limits_.data(), static_cast<int>(sz_upper_limits_), MPI_DOUBLE, 0, MPI_COMM_WORLD);
-  MPI_Bcast(common_f_values_.data(), static_cast<int>(sz_values_), MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Bcast(lower_limits_.data(), sz_lower_limits_, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Bcast(upper_limits_.data(), sz_upper_limits_, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Bcast(f_values_.data(), sz_values_, MPI_DOUBLE, 0, MPI_COMM_WORLD);
 
-  RunMultistepSchemeMethodRectangle(f_, common_f_values_, common_lower_limits_, common_upper_limits_, dim_, start_n_);
+  RunMultistepSchemeMethodRectangle(f_, f_values_, lower_limits_, upper_limits_, dim_, start_n_);
   return true;
 }
 
@@ -143,12 +136,4 @@ bool kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::PostProcess
     reinterpret_cast<double*>(task_data->outputs[0])[0] = I_2n_;
   }
   return true;
-}
-
-kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::~TestTaskALL() { MPI_Type_free(&mpi_size_t_); }
-
-MPI_Datatype kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::GetMpiType() {
-  MPI_Type_contiguous(sizeof(size_t), MPI_BYTE, &mpi_size_t_);
-  MPI_Type_commit(&mpi_size_t_);
-  return mpi_size_t_;
 }

--- a/tasks/all/kholin_k_multidimensional_integrals_rectangle/src/ops_all.cpp
+++ b/tasks/all/kholin_k_multidimensional_integrals_rectangle/src/ops_all.cpp
@@ -1,0 +1,140 @@
+#include "all/kholin_k_multidimensional_integrals_rectangle/include/ops_all.hpp"
+
+#include <mpi.h>
+#include <omp.h>
+
+#include <boost/mpi/collectives.hpp>
+#include <cmath>
+#include <cstddef>
+#include <vector>
+
+double kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::Integrate(
+    const Function& f, const std::vector<double>& l_limits, const std::vector<double>& u_limits,
+    const std::vector<double>& h, std::vector<double>& f_values, int curr_index_dim, size_t dim, double n) {
+  if (curr_index_dim == static_cast<int>(dim)) {
+    return f(f_values);
+  }
+
+  double sum = 0.0;
+  for (size_t i = 0; i < static_cast<size_t>(n); ++i) {
+    f_values[curr_index_dim] = l_limits[curr_index_dim] + (static_cast<double>(i) + 0.5) * h[curr_index_dim];
+    sum += Integrate(f, l_limits, u_limits, h, f_values, curr_index_dim + 1, dim, n);
+  }
+  return sum * h[curr_index_dim];
+}
+
+double kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::IntegrateWithRectangleMethod(
+    const Function& f, std::vector<double>& f_values, const std::vector<double>& l_limits,
+    const std::vector<double>& u_limits, size_t dim, double n) {
+  std::vector<double> h(dim);
+#pragma omp parallel for
+  for (int i = 0; i < static_cast<int>(dim); ++i) {
+    h[i] = (u_limits[i] - l_limits[i]) / n;
+  }
+  return Integrate(f, l_limits, u_limits, h, f_values, 0, dim, n);
+}
+
+double kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::RunMultistepSchemeMethodRectangle(
+    const Function& f, std::vector<double>& f_values, const std::vector<double>& l_limits,
+    const std::vector<double>& u_limits, size_t dim, double n) {
+  int rank = 0;
+  int size = 0;
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  if (rank >= 0) {
+    local_l_limits_ = std::vector<double>(dim);
+    local_u_limits_ = std::vector<double>(dim);
+  }
+  for (size_t i = 0; i < dim_; ++i) {
+    double range = u_limits[i] - l_limits[i];
+    local_l_limits_[i] = l_limits[i] + (rank * (range / size));
+    local_u_limits_[i] = l_limits[i] + ((rank + 1) * (range / size));
+  }
+  double local_result = IntegrateWithRectangleMethod(f, f_values, local_l_limits_, local_u_limits_, dim, n);
+  if (dim_ > 1) {
+    local_result = local_result * std::pow(size, dim - 1);
+  }
+  MPI_Reduce(&local_result, &I_2n_, 1, MPI_DOUBLE, MPI_SUM, 0, MPI_COMM_WORLD);
+  return I_2n_;
+}
+
+bool kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::PreProcessingImpl() {
+  int rank = 0;
+  int size = 0;
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  if (rank == 0) {
+    // Init value for input and output
+    sz_values_ = task_data->inputs_count[0];
+    sz_lower_limits_ = task_data->inputs_count[1];
+    sz_upper_limits_ = task_data->inputs_count[2];
+
+    auto* ptr_dim = reinterpret_cast<size_t*>(task_data->inputs[0]);
+    dim_ = *ptr_dim;
+
+    auto* ptr_f_values = reinterpret_cast<double*>(task_data->inputs[1]);
+    f_values_.assign(ptr_f_values, ptr_f_values + sz_values_);
+
+    auto* ptr_lower_limits = reinterpret_cast<double*>(task_data->inputs[2]);
+    lower_limits_.assign(ptr_lower_limits, ptr_lower_limits + sz_lower_limits_);
+
+    auto* ptr_upper_limits = reinterpret_cast<double*>(task_data->inputs[3]);
+    upper_limits_.assign(ptr_upper_limits, ptr_upper_limits + sz_upper_limits_);
+
+    auto* ptr_start_n = reinterpret_cast<double*>(task_data->inputs[4]);
+    start_n_ = *ptr_start_n;
+  }
+  return true;
+}
+
+bool kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::ValidationImpl() {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  mpi_size_t_ = GetMpiType();
+  if (rank == 0) {
+    return task_data->inputs_count[1] > 0U && task_data->inputs_count[2] > 0U;
+  }
+  return true;
+}
+
+bool kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::RunImpl() {
+  int size = 0;
+  int rank = 0;
+  MPI_Comm_size(MPI_COMM_WORLD, &size);
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+
+  MPI_Bcast(&sz_values_, 1, mpi_size_t_, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&sz_lower_limits_, 1, mpi_size_t_, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&sz_upper_limits_, 1, mpi_size_t_, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&dim_, 1, mpi_size_t_, 0, MPI_COMM_WORLD);
+  MPI_Bcast(&start_n_, 1, MPI_DOUBLE, 0, MPI_COMM_WORLD);
+
+  if (rank > 0) {
+    f_values_ = std::vector<double>(sz_values_);
+    lower_limits_ = std::vector<double>(sz_lower_limits_);
+    upper_limits_ = std::vector<double>(sz_upper_limits_);
+  }
+  MPI_Bcast(lower_limits_.data(), static_cast<int>(sz_lower_limits_), MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Bcast(upper_limits_.data(), static_cast<int>(sz_upper_limits_), MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Bcast(f_values_.data(), static_cast<int>(sz_values_), MPI_DOUBLE, 0, MPI_COMM_WORLD);
+
+  RunMultistepSchemeMethodRectangle(f_, f_values_, lower_limits_, upper_limits_, dim_, start_n_);
+  return true;
+}
+
+bool kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::PostProcessingImpl() {
+  int rank = 0;
+  MPI_Comm_rank(MPI_COMM_WORLD, &rank);
+  if (rank == 0) {
+    reinterpret_cast<double*>(task_data->outputs[0])[0] = I_2n_;
+  }
+  return true;
+}
+
+kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::~TestTaskALL() { MPI_Type_free(&mpi_size_t_); }
+
+MPI_Datatype kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::GetMpiType() {
+  MPI_Type_contiguous(sizeof(size_t), MPI_BYTE, &mpi_size_t_);
+  MPI_Type_commit(&mpi_size_t_);
+  return mpi_size_t_;
+}

--- a/tasks/all/kholin_k_multidimensional_integrals_rectangle/src/ops_all.cpp
+++ b/tasks/all/kholin_k_multidimensional_integrals_rectangle/src/ops_all.cpp
@@ -24,8 +24,11 @@ double kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::Integrate
   }
 
   double sum = 0.0;
+  const double l_limit = l_limits[curr_index_dim];
+  const double step = h[curr_index_dim];
+
   for (int i = 0; i < static_cast<int>(n); ++i) {
-    f_values[curr_index_dim] = l_limits[curr_index_dim] + (static_cast<double>(i) + 0.5) * h[curr_index_dim];
+    f_values[curr_index_dim] = l_limit + (static_cast<double>(i) + 0.5) * step;
     sum += Integrate(f, l_limits, u_limits, h, f_values, curr_index_dim + 1, dim, n);
   }
   return sum * h[curr_index_dim];

--- a/tasks/all/kholin_k_multidimensional_integrals_rectangle/src/ops_all.cpp
+++ b/tasks/all/kholin_k_multidimensional_integrals_rectangle/src/ops_all.cpp
@@ -1,6 +1,15 @@
 #include "all/kholin_k_multidimensional_integrals_rectangle/include/ops_all.hpp"
 
+#ifdef __clang__
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wcast-align"
+#endif
+
 #include <mpi.h>
+
+#ifdef __clang__
+#pragma clang diagnostic pop
+#endif
 #include <omp.h>
 
 #include <boost/mpi/collectives.hpp>

--- a/tasks/all/kholin_k_multidimensional_integrals_rectangle/src/ops_all.cpp
+++ b/tasks/all/kholin_k_multidimensional_integrals_rectangle/src/ops_all.cpp
@@ -118,16 +118,21 @@ bool kholin_k_multidimensional_integrals_rectangle_all::TestTaskALL::RunImpl() {
   MPI_Bcast(&dim_, 1, mpi_size_t_, 0, MPI_COMM_WORLD);
   MPI_Bcast(&start_n_, 1, MPI_DOUBLE, 0, MPI_COMM_WORLD);
 
-  if (rank > 0) {
-    f_values_ = std::vector<double>(sz_values_);
-    lower_limits_ = std::vector<double>(sz_lower_limits_);
-    upper_limits_ = std::vector<double>(sz_upper_limits_);
+  if (rank >= 0) {
+    common_f_values_ = std::vector<double>(sz_values_);
+    common_lower_limits_ = std::vector<double>(sz_lower_limits_);
+    common_upper_limits_ = std::vector<double>(sz_upper_limits_);
+    if (rank == 0) {
+      common_f_values_.assign(f_values_.begin(), f_values_.end());
+      common_lower_limits_.assign(lower_limits_.begin(), lower_limits_.end());
+      common_upper_limits_.assign(upper_limits_.begin(), upper_limits_.end());
+    }
   }
-  MPI_Bcast(lower_limits_.data(), static_cast<int>(sz_lower_limits_), MPI_DOUBLE, 0, MPI_COMM_WORLD);
-  MPI_Bcast(upper_limits_.data(), static_cast<int>(sz_upper_limits_), MPI_DOUBLE, 0, MPI_COMM_WORLD);
-  MPI_Bcast(f_values_.data(), static_cast<int>(sz_values_), MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Bcast(common_lower_limits_.data(), static_cast<int>(sz_lower_limits_), MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Bcast(common_upper_limits_.data(), static_cast<int>(sz_upper_limits_), MPI_DOUBLE, 0, MPI_COMM_WORLD);
+  MPI_Bcast(common_f_values_.data(), static_cast<int>(sz_values_), MPI_DOUBLE, 0, MPI_COMM_WORLD);
 
-  RunMultistepSchemeMethodRectangle(f_, f_values_, lower_limits_, upper_limits_, dim_, start_n_);
+  RunMultistepSchemeMethodRectangle(f_, common_f_values_, common_lower_limits_, common_upper_limits_, dim_, start_n_);
   return true;
 }
 


### PR DESCRIPTION
**ПОСТАНОВКА ЗАДАЧИ ДЛЯ ОДНОМЕРНОГО ИНТЕГРАЛА**
Необходимо вычислить определённый интеграл на отрезке ([a, b]). Этот
отрезок разбивается на (n) равных частей, где длина каждой части
определяется как

$$ h = \frac{b - a}{n}. $$

b и a - конец и начала отрезка. Вместо b и а подставляются пределы
интегрирования, n - число шагов.

Обозначим через $$f\left(x_{i-1} + \frac{h}{2}\right)$$ значение функции
в середине каждого частичного отрезка. Затем составим сумму произведений
всех таких значений $$f\left(x_{i-1} + \frac{h}{2}\right)$$ на h — шаг
отрезка. Полученная сумма будет представлять собой приближённое значение
определённого интеграла на отрезке ([a, b]) по формуле средних
прямоугольников:

$$ \int_{a}^{b} f(x) , dx \approx h \sum_{i=1}^{n} f\left(x_{i-1} +
\frac{h}{2}\right) = h \sum_{i=1}^{n} f\left(x_{i} - \frac{h}{2}\right).
$$

**ПОСТАНОВКА ЗАДАЧИ ДЛЯ МНОГОМЕРНОГО ИНТЕГРАЛА**
Задача аналогичная задаче одномерного случая. n-мерная область
разбивается на равные части. по каждому измерению. Выбираем центр каждой
части по каждому измерению. Шаг по каждому измерению вычисляется как

$$ h = \frac{b - a}{n}. $$

b и a - конец и начала отрезка. Вместо b и а подставляются пределы
интегрирования по каждому измерению соответственно, n - число шагов.

Общая формула для d-мерного интеграла:
Δx = (b - a) / n = h

$$I \approx \sum_{i_1=1}^n \sum_{i_2=1}^n \dots \sum_{i_d=1}^n
f(x_{i_1}, x_{i_2}, \dots, x_{i_d}) \cdot (\Delta x)^d,$$

где

$$x_{i_k} = a + (i_k - \frac{1}{2}) \cdot \Delta x, \ k = 1, \dots, d.$$

**ОПИСАНИЕ РЕШЕНИЯ**
_[MPI + OMP ТЕХНОЛОГИЯ]_

_СУТЬ ОПИСАНИЯ РЕШЕНИЯ_ 
Выполнить распараллеливание цикла внутри метода интегрирования Integrate. Для процессов MPI нужно поделить отрезки интегрирования равномерно по каждой размерности между процессами. На следующем шаге использовать директиву #pragma omp parallel for для распределения работы между потоками внутри цикла вектора шагов по каждой размерности. Применение директивы в текущем контексты уместно, поскольку позволит ускорить старт вычисления интегральных частичных сумм. После того, как вся работы между процессами и потоками будет распределена, начнутся вычисления.

_ЭФФЕКТИВНОСТЬ_
Распределение работы между процессами по вычислению по каждой размерности своей частичной интегральной суммы даёт значительное ускорение, так как процессы работают независимо друг от друга, а предварительное распределение задач между потоками по подсчёту шагов по каждой размерности даёт небольшое ускорение в старте основной работы процессов.


**СПИСОК ИЗМЕНЕНИЙ**
- Убраны ненужные хедеры;
- Спецификатор лямбда-выражения захватывает поля задачи(this);
- Уменьшено число шагов для тестов тройных интегралов для Ubuntu ОС;